### PR TITLE
fix(init): Always run in current working directory unless `--cwd` is passed

### DIFF
--- a/src/AtSCMCli.js
+++ b/src/AtSCMCli.js
@@ -1,4 +1,5 @@
 import { realpathSync } from 'fs';
+import { join } from 'path';
 import Liftoff from 'liftoff';
 import yargs from 'yargs';
 import gulplog from 'gulplog';
@@ -161,13 +162,17 @@ export default class AtSCMCli extends Liftoff {
 
   /**
    * Returns a {@link Liftoff.Environment} for the Cli.
+   * @param {Boolean} [findUp=false] If the environment should be searched for in parent
+   * directories.
    * @return {Promise<Object>} Fulfilled with a {@link Liftoff} environment.
    */
-  getEnvironment() {
+  getEnvironment(findUp = true) {
     return new Promise(resolve => {
       super.launch({
         cwd: this.options.cwd,
-        configPath: this.options.projectfile,
+        configPath: findUp ?
+          this.options.projectfile :
+          join((this.options.cwd || process.cwd()), `${this.constructor.ConfigName}.js`),
         require: this.options.require,
       }, env => resolve(this.environment = env));
     });

--- a/src/cli/commands/Init.js
+++ b/src/cli/commands/Init.js
@@ -194,11 +194,11 @@ export default class InitCommand extends Command {
    * @param {AtSCMCli} cli The current Cli instance.
    */
   run(cli) {
-    return cli.getEnvironment()
+    return cli.getEnvironment(false)
       .then(env => this.checkDirectory(env.cwd, cli.options.force))
       .then(() => this.createEmptyPackage(cli.environment.cwd))
       .then(() => this.installLocal(cli.environment.cwd))
-      .then(() => cli.getEnvironment())
+      .then(() => cli.getEnvironment(false))
       .then(env => this.checkCliVersion(env))
       .then(env => process.chdir(env.cwd))
       .then(() => this.getOptions(cli.environment.modulePath))

--- a/test/AtSCMCli.spec.js
+++ b/test/AtSCMCli.spec.js
@@ -142,9 +142,9 @@ describe('AtSCMCli', function() {
           .then(env => expect(env.cwd, 'to equal', process.cwd()));
       });
 
-      it('should resolve to initial cwd in project child directories', function() {
-        const projChildDir = 'test/fixtures/node_modules';
+      const projChildDir = join('test/fixtures/node_modules');
 
+      it('should resolve to initial cwd in project child directories', function() {
         return (new AtSCMCli([
           '--cwd', projChildDir,
         ])).getEnvironment(false)
@@ -152,8 +152,6 @@ describe('AtSCMCli', function() {
       });
 
       it('should ignore --projectfile option', function() {
-        const projChildDir = 'test/fixtures/node_modules';
-
         return (new AtSCMCli([
           '--cwd', projChildDir,
           '--projectfile', join(projChildDir, '../Atviseproject.js'),

--- a/test/AtSCMCli.spec.js
+++ b/test/AtSCMCli.spec.js
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import expect from 'unexpected';
 import { spy, stub } from 'sinon';
 import proxyquire from 'proxyquire';
@@ -133,6 +134,32 @@ describe('AtSCMCli', function() {
             ['cwd', 'configPath', 'configBase', 'modulePath', 'modulePackage']
           );
         });
+    });
+
+    context('when not looking up parent directories', function() {
+      it('should resolve to initial cwd', function() {
+        return (new AtSCMCli()).getEnvironment(false)
+          .then(env => expect(env.cwd, 'to equal', process.cwd()));
+      });
+
+      it('should resolve to initial cwd in project child directories', function() {
+        const projChildDir = 'test/fixtures/node_modules';
+
+        return (new AtSCMCli([
+          '--cwd', projChildDir,
+        ])).getEnvironment(false)
+          .then(env => expect(env.cwd, 'to end with', projChildDir));
+      });
+
+      it('should ignore --projectfile option', function() {
+        const projChildDir = 'test/fixtures/node_modules';
+
+        return (new AtSCMCli([
+          '--cwd', projChildDir,
+          '--projectfile', join(projChildDir, '../Atviseproject.js'),
+        ])).getEnvironment(false)
+          .then(env => expect(env.cwd, 'to end with', projChildDir));
+      });
     });
   });
 

--- a/test/cli/commands/Init.spec.js
+++ b/test/cli/commands/Init.spec.js
@@ -282,7 +282,7 @@ describe('InitCommand', function() {
         cwd: stubModulePath,
       },
       options: {
-        force: false
+        force: false,
       },
       getEnvironment: spy(() => Promise.resolve({
         cwd: stubModulePath,
@@ -317,6 +317,11 @@ describe('InitCommand', function() {
 
     it('should call AtSCMCli#getEnvironment twice', function() {
       return expectCalled(cli.getEnvironment, 2);
+    });
+
+    it('should not search in parent directories', function() {
+      return expect(command.run(cli), 'to be fulfilled')
+        .then(() => expect(cli.getEnvironment.alwaysCalledWith(false), 'to equal', true));
     });
 
     it('should call InitCommand#createEmptyPackage', function() {


### PR DESCRIPTION
Fixes #14