### PR TITLE
feat(docs): Open hosted API documentation with `--remote` option passed

### DIFF
--- a/src/cli/Options.js
+++ b/src/cli/Options.js
@@ -11,6 +11,7 @@ import Option from '../lib/cli/Option';
  * @property {Option} help Show help.
  * @property {Option} logLevel Set the Logger level.
  * @property {Option} projectfile Manually set path of Atviseproject file to use.
+ * @property {Option} remote Open hosted documentation.
  * @property {Option} silent Supress all logging.
  * @property {Option} version Print version.
  */
@@ -32,6 +33,9 @@ const Options = {
     'This will set the CWD to the Atviseproject file\'s directory as well.',
     { alias: 'p' }),
   require: Option.string('Will require a module before running atscm.'),
+  remote: Option.boolean('Open hosted documentation.', {
+    default: undefined,
+  }),
   silent: Option.boolean('Suppress all logging.', { alias: 'S' }),
   tasks: Option.boolean('Print the task dependency tree.', {
     alias: 'T',

--- a/src/cli/commands/Docs.js
+++ b/src/cli/commands/Docs.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { resolve } from 'url';
 import open from 'open';
 import Command from '../../lib/cli/Command';
 import CliOptions from '../Options';
@@ -10,6 +11,14 @@ import Logger from '../../lib/util/Logger';
 export default class DocsCommand extends Command {
 
   /**
+   * Base URL of the hosted API documentation.
+   * @type {string}
+   */
+  static get RemoteDocsBase() {
+    return 'https://doc.esdoc.org/github.com/atSCM/';
+  }
+
+  /**
    * Creates a new {@link DocsCommand} with the specified name and description.
    * @param {String} name The command's name.
    * @param {String} description The command's description.
@@ -19,17 +28,18 @@ export default class DocsCommand extends Command {
       options: {
         cli: CliOptions.cli,
         browser: CliOptions.browser,
+        remote: CliOptions.remote,
       },
       maxArguments: 0,
     });
   }
 
   /**
-   * Returns the path to the api docs to open.
+   * Returns the path to the local api docs.
    * @param {AtSCMCli} cli The current Cli instance.
-   * @return {String} The path to the api docs to opten.
+   * @return {string} The path to the local api docs.
    */
-  pathToOpen(cli) {
+  localDocsPath(cli) {
     return join(
       cli.options.cli ?
         join(__dirname, '../../../') :
@@ -39,14 +49,54 @@ export default class DocsCommand extends Command {
   }
 
   /**
+   * Returns the URL of the remote api docs.
+   * @param {AtSCMCli} cli The current Cli instance.
+   * @return {string} The URL of the remote api docs.
+   */
+  remoteDocsUrl(cli) {
+    return resolve(this.constructor.RemoteDocsBase, cli.options.cli ?
+      'atscm-cli' :
+      'atscm');
+  }
+
+  /**
+   * Returns the path or url to open. This is resolved in the following way:
+   *  1. If `--remote` is passed, always return the URL of the hosted docs of atscm-cli or atscm
+   *     based on the `--cli` option passed.
+   *  2. If `--cli` is passed, always return the path to the local atscm-cli docs.
+   *  3. Otherwise, check if a local module was found:
+   *     - If *true* return the local module docs path,
+   *     - else return the URL of the hosted atscm docs.
+   * @param {AtSCMCli} cli The calling Cli instance.
+   * @return {{address: string, isPath: boolean}} The resolved address and a flag indicating if the
+   * address describes a file path.
+   */
+  addressToOpen(cli) {
+    if (cli.options.remote !== true && (cli.options.cli || cli.environment.modulePath)) {
+      return {
+        address: this.localDocsPath(cli),
+        isPath: true,
+      };
+    }
+
+    return {
+      address: this.remoteDocsUrl(cli),
+      isPath: false,
+    };
+  }
+
+  /**
    * Opens the requested docs in the requested browser.
    * @param {AtSCMCli} cli The current Cli instance.
+   * @return {Promise} Resolved after the os-specific open command was started.
    */
   run(cli) {
-    const docsPath = this.pathToOpen(cli);
-    Logger.debug('Opening', Logger.format.path(docsPath));
-
-    open(docsPath, cli.options.browser);
+    return (!cli.options.cli && !cli.environment ? cli.getEnvironment() : Promise.resolve())
+      .then(() => this.addressToOpen(cli))
+      .then(({ address, isPath }) => {
+        Logger.debug('Opening', isPath ? Logger.format.path(address) : address);
+        open(address, cli.options.browser);
+      });
   }
 
   /**
@@ -55,7 +105,7 @@ export default class DocsCommand extends Command {
    * @return {Boolean} `false` if the `--cli` option is used.
    */
   requiresEnvironment(cli) {
-    return !cli.options.cli;
+    return cli.options.remote === false && !cli.options.cli;
   }
 
 }

--- a/test/cli/commands/Docs.spec.js
+++ b/test/cli/commands/Docs.spec.js
@@ -12,11 +12,11 @@ const DocsCommand = proxyquire('../../../src/cli/commands/Docs', {
 describe('DocsCommand', function() {
   const command = new DocsCommand('docs', 'Open documentation.');
 
-  /** @test {DocsCommand#pathToOpen} */
-  describe('#pathToOpen', function() {
+  /** @test {DocsCommand#localDocsPath} */
+  describe('#localDocsPath', function() {
     it('should be local api docs by default', function() {
       expect(
-        command.pathToOpen({
+        command.localDocsPath({
           options: {},
           environment: {
             modulePath: '/path/to/package.json',
@@ -28,11 +28,73 @@ describe('DocsCommand', function() {
 
     it('should be cli api docs with --cli option', function() {
       expect(
-        command.pathToOpen({
+        command.localDocsPath({
           options: { cli: true },
         }),
         'to equal', join(__dirname, '../../../docs/api/index.html')
       );
+    });
+  });
+
+  /** @test {DocsCommand#remoteDocsUrl} */
+  describe('#remoteDocsUrl', function() {
+    it('should return path to atscm docs by default', function() {
+      expect(command.remoteDocsUrl({ options: {} }),
+        'to equal', `${DocsCommand.RemoteDocsBase}atscm`);
+    });
+
+    it('should return path to atscm-cli docs with `--cli` option passed', function() {
+      expect(command.remoteDocsUrl({ options: { cli: true } }),
+        'to equal', `${DocsCommand.RemoteDocsBase}atscm-cli`,);
+    });
+  });
+
+  /** @test {DocsCommand#addressToOpen} */
+  describe('#addressToOpen', function() {
+    it('should return local path if not remote option was passed', function() {
+      const { address, isPath } = command.addressToOpen({
+        options: {},
+        environment: { modulePath: '/path/to/package.json' }
+      });
+
+      expect(address, 'to equal', join('/path/docs/api/index.html'));
+      expect(isPath, 'to equal', true);
+    });
+
+    it('should return local path if remote option was set to false', function() {
+      const { isPath } = command.addressToOpen({
+        options: { remote: false },
+        environment: { modulePath: '/path/to/package.json' }
+      });
+
+      expect(isPath, 'to equal', true);
+    });
+
+    it('should return remote url if remote was set to true', function() {
+      const { isPath } = command.addressToOpen({
+        options: { remote: true },
+        environment: { modulePath: '/path/to/package.json' }
+      });
+
+      expect(isPath, 'to equal', false);
+    });
+
+    it('should return remote url if cli.env.modulePath is undefined', function() {
+      const { isPath } = command.addressToOpen({
+        options: { remote: true },
+        environment: {}
+      });
+
+      expect(isPath, 'to equal', false);
+    });
+
+    it('should return local path if cli option was set', function() {
+      const { isPath } = command.addressToOpen({
+        options: { cli: true },
+        environment: {}
+      });
+
+      expect(isPath, 'to equal', true);
     });
   });
 
@@ -46,11 +108,12 @@ describe('DocsCommand', function() {
         environment: {
           modulePath: '/path/to/package.json',
         },
-      });
-
-      expect(openSpy.calledOnce, 'to be', true);
-      expect(openSpy.lastCall.args[0], 'to equal', join('/path/docs/api/index.html'));
-      expect(openSpy.lastCall.args[1], 'to be undefined');
+      })
+        .then(() => {
+          expect(openSpy.calledOnce, 'to be', true);
+          expect(openSpy.lastCall.args[0], 'to equal', join('/path/docs/api/index.html'));
+          expect(openSpy.lastCall.args[1], 'to be undefined');
+        });
     });
 
     it('should open cli api docs with --cli option', function() {
@@ -58,11 +121,13 @@ describe('DocsCommand', function() {
         options: {
           cli: true,
         },
-      });
-
-      expect(openSpy.calledOnce, 'to be', true);
-      expect(openSpy.lastCall.args[0], 'to equal', join(__dirname, '../../../docs/api/index.html'));
-      expect(openSpy.lastCall.args[1], 'to be undefined');
+      })
+        .then(() => {
+          expect(openSpy.calledOnce, 'to be', true);
+          expect(openSpy.lastCall.args[0],
+            'to equal', join(__dirname, '../../../docs/api/index.html'));
+          expect(openSpy.lastCall.args[1], 'to be undefined');
+        });
     });
 
     it('should open in specific browser with --browser option', function() {
@@ -74,11 +139,49 @@ describe('DocsCommand', function() {
         environment: {
           modulePath: '/path/to/package.json',
         },
-      });
+      })
+        .then(() => {
+          expect(openSpy.calledOnce, 'to be', true);
+          expect(openSpy.lastCall.args[0], 'to equal', join('/path/docs/api/index.html'));
+          expect(openSpy.lastCall.args[1], 'to equal', 'custombrowser');
+        });
+    });
 
-      expect(openSpy.calledOnce, 'to be', true);
-      expect(openSpy.lastCall.args[0], 'to equal', join('/path/docs/api/index.html'));
-      expect(openSpy.lastCall.args[1], 'to equal', 'custombrowser');
+    it('should call AtSCMCli#getEnvironment if no environment was passed', function() {
+      const cli = {
+        options: {
+          cli: false,
+        },
+        getEnvironment() {
+          return Promise.resolve((this.environment = {
+            modulePath: '/path/to/package.json',
+          }));
+        }
+      };
+
+      spy(cli, 'getEnvironment');
+
+      command.run(cli)
+        .then(() => {
+          expect(cli.getEnvironment.calledOnce, 'to be', true);
+          expect(openSpy.calledOnce, 'to be', true);
+          expect(openSpy.lastCall.args[0], 'to equal', join('/path/docs/api/index.html'));
+        });
+    });
+
+    it('should open remote docs with --remote option passed', function() {
+      command.run({
+        options: {
+          remote: true,
+        },
+        environment: {
+          modulePath: '/path/to/package.json',
+        },
+      })
+        .then(() => {
+          expect(openSpy.calledOnce, 'to be', true);
+          expect(openSpy.lastCall.args[0], 'to start with', DocsCommand.RemoteDocsBase);
+        });
     });
   });
 
@@ -86,6 +189,25 @@ describe('DocsCommand', function() {
   describe('#requiresEnvironment', function() {
     it('should return false if `--cli` is used', function() {
       expect(command.requiresEnvironment({ options: { cli: true } }), 'to be', false);
+    });
+
+    it('should return false if `--remote`', function() {
+      expect(command.requiresEnvironment({ options: { remote: true } }), 'to be', false);
+    });
+
+    it('should return false if no `--remote` option is passed', function() {
+      expect(command.requiresEnvironment({ options: { } }), 'to be', false);
+    });
+
+    it('should return false if `--no-remote` and `--cli` option is passed', function() {
+      expect(command.requiresEnvironment({ options: {
+        remote: false,
+        cli: true,
+      } }), 'to be', false);
+    });
+
+    it('should return true if `--no-remote` and no `--cli` option is passed', function() {
+      expect(command.requiresEnvironment({ options: { remote: false } }), 'to be', true);
     });
   });
 });


### PR DESCRIPTION
Fixes #13