### PR TITLE
fix(run): Allow `atscm --tasks` with current gulp-cli version

### DIFF
--- a/src/cli/commands/Run.js
+++ b/src/cli/commands/Run.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import colors from 'chalk';
 import Command from '../../lib/cli/Command';
 import CliOptions from '../Options';
 
@@ -45,6 +46,8 @@ export default class RunCommand extends Command {
       {
         configPath: join(cli.environment.modulePath, '../Gulpfile.js'),
         modulePath: join(cli.environment.cwd, 'node_modules/gulp'),
+      }, {
+        description: colors.bold('Available tasks:'),
       });
   }
 

--- a/test/cli/commands/Run.spec.js
+++ b/test/cli/commands/Run.spec.js
@@ -36,19 +36,18 @@ describe('RunCommand', function() {
       command.run(cli);
 
       expect(gulpCli.calledOnce, 'to be', true);
-      expect(gulpCli.lastCall.args, 'to equal', [
-        {
-          _: ['task1', 'task2'],
-          tasks: 'tasks',
-          tasksSimple: 'tasks-simple',
-          tasksJson: 'tasks-json',
-          continue: 'continue',
-        },
-        {
-          configPath: join(__dirname, 'out/Gulpfile.js'),
-          modulePath: join(__dirname, 'node_modules/gulp'),
-        },
-      ]);
+      expect(gulpCli.lastCall.args, 'to contain', {
+        _: ['task1', 'task2'],
+        tasks: 'tasks',
+        tasksSimple: 'tasks-simple',
+        tasksJson: 'tasks-json',
+        continue: 'continue',
+      });
+
+      expect(gulpCli.lastCall.args, 'to contain', {
+        configPath: join(__dirname, 'out/Gulpfile.js'),
+        modulePath: join(__dirname, 'node_modules/gulp'),
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #22 