### PR TITLE
add source maps and beta flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=6.0"
   },
   "scripts": {
-    "compile": "babel src --out-dir out",
+    "compile": "babel src --out-dir out --source-maps",
     "compile:watch": "npm run compile -- --watch",
     "docs": "esdoc -c esdoc.json",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atscm-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "atSCM command line interface",
   "main": "out/AtSCMCli.js",
   "bin": {

--- a/src/cli/Options.js
+++ b/src/cli/Options.js
@@ -14,6 +14,7 @@ import Option from '../lib/cli/Option';
  * @property {Option} remote Open hosted documentation.
  * @property {Option} silent Supress all logging.
  * @property {Option} version Print version.
+ * @property {Option} beta Use atscm beta resources.
  */
 const Options = {
   browser: Option.string('Which browser to open in.'),
@@ -44,6 +45,7 @@ const Options = {
   'tasks-simple': Option.boolean('Print a plaintext list of tasks.'),
   'tasks-json': Option.boolean('Print the task dependency tree, in JSON format.'),
   version: Option.boolean('Print version.', { alias: 'v' }),
+  beta: Option.boolean('Use atscm beta resources'),
 };
 
 export default Options;
@@ -60,5 +62,6 @@ export const GlobalOptions = {
   version: Options.version,
   help: Options.help,
   silent: Options.silent,
+  beta: Options.beta,
   'log-level': Options['log-level'],
 };

--- a/src/cli/commands/Init.js
+++ b/src/cli/commands/Init.js
@@ -123,7 +123,7 @@ export default class InitCommand extends Command {
     Logger.info('Installing latest version of atscm...');
 
     // FIXME: call with (path, 'atscm') once atscm is published
-    return this.install(path, 'atscm');
+    return this.install(path, process.argv.indexOf('beta') > -1 ? 'atscm@beta' : 'atscm');
   }
 
   /**


### PR DESCRIPTION
Adds "source-maps" switch in compile task call to
generate source-maps with babel. This makes it
possible to avoid debugging of transpiled files in
Webstorm node environment and may other
environments too